### PR TITLE
SEPIO-ification of clingen-gdi1-gene-validity-example.json

### DIFF
--- a/workspace/clingen-gdi1-gene-validity-example.json
+++ b/workspace/clingen-gdi1-gene-validity-example.json
@@ -10,7 +10,7 @@
     "type": "GeneValidityProposition",
     "subjectGene": "hgnc:4226",    
     "objectDisease": "obo:MONDO_0019181",
-    "predicate": "mutations_may_be_causal_for",         # Predicate requried in SEPIO/VA - to be explicit about the relationship b/t subject and object
+    "predicate": "mutations_can cause",         # Predicate requried in SEPIO/VA - to be explicit about the relationship b/t subject and object
     "modeOfInheritanceQualifier": "obo:HP_0001417"
   },
   "direction": "supports",                              # Should always be provided for a SEPIO Statement
@@ -18,7 +18,7 @@
   "strength": "Moderate",
   "curationReasonDescription": "Downgraded for ...",    # non-SEPIO property - would need to use an extension
   "score": 11.3,
-  "specifiedBy": "GeneValidityCriteria10",
+  "specifiedBy": "GeneValidityCriteria10",              # needs to be a Method object or a reference to one . . . is this the id for one?
   "contributions": [
     {
       "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_contrib",
@@ -60,9 +60,9 @@
           "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/f13b920a-fcce-4133-a04b-24d8ffafcaae_variant_evidence_item",
-              "type": "VariantObservation",              # Currently no model of "Observations" in SEPIO/VA, but this has been explored and can be added
+              "type": "VariantObservation",              # Currently no model of "Observations" in SEPIO/VA, but this has been explored and can be added. Alt, use the existing StudyResult object to capture observation data?
               "dc:source": "https://pubmed.ncbi.nlm.nih.gov/22002931",
-              "allele": {
+              "allele": {                                # Is this intended to be a GA4GH VRS allele object? Seems to use outdate 'Descriptor' modeling.
                 "id": "https://genegraph.clinicalgenome.org/r/b152381d-b705-4ef5-93ba-bfd27d966769",
                 "type": "https://terms.ga4gh.org/VariationDescriptor",
                 "http://www.w3.org/2004/02/skos/core#prefLabel": "NM_001493.3(GDI1):c.1186_1187del (p.Ser396ProfsTer15)",
@@ -95,7 +95,7 @@
               "functionalDataSupport": "Yes"              # Not supported by SEPIO/VA -  but if this is really needed, it seems like it might fit better on the EvidenceLine above?
             },
             {
-              "id": "https://genegraph.clinicalgenome.org/r/23ee3af1-ac4e-42fd-b756-79ec36dee819_variant_evidence_item"   # A reference to the supporting VariantObservation, fully specified elsewhere in the doc. 
+              "id": "https://genegraph.clinicalgenome.org/r/23ee3af1-ac4e-42fd-b756-79ec36dee819_variant_evidence_item"   # A reference to the supporting VariantObservation, fully specified elsewhere in the doc (in a Family Co-Seg object, reporting observation of this variant there)
             }
           ]
         },

--- a/workspace/clingen-gdi1-gene-validity-example.json
+++ b/workspace/clingen-gdi1-gene-validity-example.json
@@ -48,7 +48,7 @@
       "directionOfEvidenceProvided": "supports",              # Added this in - direction of support should always be explicitly declared for SEPIO/VA evidence lines
       "scoreOfEvidenceProvided": 5.8,
       "specifiedBy": "GeneValidityOverallGeneticEvidenceCriteria",
-      "hasEvidenceLines": [
+      "hasEvidenceItems": [
         {
           "id": "https://genegraph.clinicalgenome.org/r/f13b920a-fcce-4133-a04b-24d8ffafcaae",
           "type": "EvidenceLine",

--- a/workspace/clingen-gdi1-gene-validity-example.json
+++ b/workspace/clingen-gdi1-gene-validity-example.json
@@ -1,60 +1,66 @@
 {
   "id": "https://genegraph.clinicalgenome.org/r/a0a9ec11-ef90-4095-9c9e-696eabd0395bv1.0",
   "type": "EvidenceStrengthAssertion",
-  "dc:description": [
+  "description": [
     "*GDI1* was first reported ...",
     "*GDI1* was first reported ..."
   ],
-  "subject": {
+  "proposition": {
     "id": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
     "type": "GeneValidityProposition",
-    "gene": "hgnc:4226",
-    "disease": "obo:MONDO_0019181",
-    "modeOfInheritance": "obo:HP_0001417"
+    "subjectGene": "hgnc:4226",    
+    "objectDisease": "obo:MONDO_0019181",
+    "predicate": "mutations_may_be_causal_for",         # Predicate requried in SEPIO/VA - to be explicit about the relationship b/t subject and object
+    "modeOfInheritanceQualifier": "obo:HP_0001417"
   },
-  "calculatedEvidenceStrength": "Definitive",
-  "evidenceStrength": "Moderate",
-  "curationReasonDescription": "Downgraded for ...",
-  "strengthScore": 11.3,
+  "direction": "supports",                              # Should always be provided for a SEPIO Statement
+  "calculatedEvidenceStrength": "Definitive",           # non-SEPIO property - would need to use an extension
+  "strength": "Moderate",
+  "curationReasonDescription": "Downgraded for ...",    # non-SEPIO property - would need to use an extension
+  "score": 11.3,
   "specifiedBy": "GeneValidityCriteria10",
   "contributions": [
     {
       "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_contrib",
-      "agent": "https://genegraph.clinicalgenome.org/agent/10006",
-      "date": [
+      "contributor": "https://genegraph.clinicalgenome.org/agent/10006",
+
+      "date": [                                         # only 1 date allowed by SEPIO - why are there two here?
         "2023-04-27T06:00:00.000Z",
         "2023-04-26T22:00:00.000Z"
       ],
-      "role": "Approver"
+      "activityType": "Approver"
     },
     {
       "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_publish_contrib",
-      "agent": "https://genegraph.clinicalgenome.org/agent/10006",
+      "contributor": "https://genegraph.clinicalgenome.org/agent/10006",
       "date": "2025-08-04T13:27:39.754Z",
-      "role": "Publisher"
+      "activityType": "Publisher"
     }
   ],
-  "curationReasons": [
-    "ErrorClarification"
+  "curationReasons": [                                  # non-SEPIO property - would need to use an 'Extension' to be SEPIO/VA compliant
+      "ErrorClarification"
   ],
-  "evidence": [
+  "hasEvidenceLines": [
     {
       "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_overall_genetic_evidence_line",
       "type": "EvidenceLine",
-      "strengthScore": 5.8,
+      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk", # Added this in - not needed, but this is how you would explicitly declare that the evidence is assessed toward the root gene validity proposition
+      "directionOfEvidenceProvided": "supports",              # Added this in - direction of support should always be explicitly declared for SEPIO/VA evidence lines
+      "scoreOfEvidenceProvided": 5.8,
       "specifiedBy": "GeneValidityOverallGeneticEvidenceCriteria",
-      "evidence": [
+      "hasEvidenceLines": [
         {
           "id": "https://genegraph.clinicalgenome.org/r/f13b920a-fcce-4133-a04b-24d8ffafcaae",
           "type": "EvidenceLine",
-          "direction": "Supports",
-          "calculatedScore": 1.5,
-          "strengthScore": 1.5,
-          "specifiedBy": "GeneValidityNullVariantCriteria",
-          "evidence": [
+          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "supports",
+          "calculatedScore": 1.5,                             # non-SEPIO property - would need to use an 'Extension' to be SEPIO/VA compliant
+          "scoreOfEvidenceProvided": 1.5,
+          "specifiedBy": "GeneValidityNullVariantCriteria",   # Value of 'specifiedBy' would need to be a 'Method' object to be VA/SEPIO compliant
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/f13b920a-fcce-4133-a04b-24d8ffafcaae_variant_evidence_item",
-              "type": "VariantObservation",
+              "type": "VariantObservation",              # Currently no model of "Observations" in SEPIO/VA, but this has been explored and can be added
               "dc:source": "https://pubmed.ncbi.nlm.nih.gov/22002931",
               "allele": {
                 "id": "https://genegraph.clinicalgenome.org/r/b152381d-b705-4ef5-93ba-bfd27d966769",
@@ -76,30 +82,32 @@
         {
           "id": "https://genegraph.clinicalgenome.org/r/23ee3af1-ac4e-42fd-b756-79ec36dee819",
           "type": "EvidenceLine",
-          "direction": "Supports",
-          "calculatedScore": 2,
-          "strengthScore": 2,
+          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "Supports",
+          "calculatedScore": 2,                           # non-SEPIO/VA property
+          "scoreOfEvidenceProvided": 2,
           "specifiedBy": "GeneValidityNullVariantCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/23ee3af1-ac4e-42fd-b756-79ec36dee819_function_evidence_item",
-              "type": "VariantFunctionalImpactEvidence",
+              "type": "VariantFunctionalImpactEvidence",  # This would likely be represented as an ExperimentalFunctionalImpactStudyResult in SEPIO/VA.  MAVE defined a model of this for their use case, which may need to be expanded to support yours.  
               "dc:description": "Western blot shows no GDI1 protein expression in affected patient.",
-              "functionalDataSupport": "Yes"
+              "functionalDataSupport": "Yes"              # Not supported by SEPIO/VA -  but if this is really needed, it seems like it might fit better on the EvidenceLine above?
             },
             {
-              "id": "https://genegraph.clinicalgenome.org/r/23ee3af1-ac4e-42fd-b756-79ec36dee819_variant_evidence_item"
+              "id": "https://genegraph.clinicalgenome.org/r/23ee3af1-ac4e-42fd-b756-79ec36dee819_variant_evidence_item"   # A reference to the supporting VariantObservation, fully specified elsewhere in the doc. 
             }
           ]
         },
         {
           "id": "https://genegraph.clinicalgenome.org/r/9006bb0f-0e43-4b09-b352-cd78f89a4996",
           "type": "EvidenceLine",
-          "direction": "Supports",
-          "calculatedScore": 0.1,
-          "strengthScore": 0.1,
+	      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "Supports",
+          "calculatedScore": 0.1,                         # non-SEPIO/VA property
+          "scoreOfEvidenceProvided": 0.1,
           "specifiedBy": "GeneValidityNonNullVariantCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/9006bb0f-0e43-4b09-b352-cd78f89a4996_variant_evidence_item",
               "type": "VariantObservation",
@@ -124,11 +132,12 @@
         {
           "id": "https://genegraph.clinicalgenome.org/r/c32b5768-9709-44e7-ada4-f835921e384b",
           "type": "EvidenceLine",
-          "direction": "Supports",
-          "calculatedScore": 0.1,
-          "strengthScore": 0.1,
+	      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "Supports",
+          "calculatedScore": 0.1,                         # non-SEPIO/VA property
+          "scoreOfEvidenceProvided": 0.1,
           "specifiedBy": "GeneValidityNonNullVariantCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/c32b5768-9709-44e7-ada4-f835921e384b_variant_evidence_item"
             }
@@ -137,11 +146,12 @@
         {
           "id": "https://genegraph.clinicalgenome.org/r/dd79d3ee-7c6d-4539-8da6-14b2da391a9c",
           "type": "EvidenceLine",
-          "direction": "Supports",
-          "calculatedScore": 0.5,
-          "strengthScore": 0.5,
+	      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "Supports",
+          "calculatedScore": 0.5,                         # non-SEPIO/VA property 
+          "scoreOfEvidenceProvided": 0.5,
           "specifiedBy": "GeneValidityNonNullVariantCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/dd79d3ee-7c6d-4539-8da6-14b2da391a9c_function_evidence_item",
               "type": "VariantFunctionalImpactEvidence",
@@ -156,12 +166,14 @@
         {
           "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_seg_el",
           "type": "EvidenceLine",
-          "strengthScore": 1.6,
+	      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "Supports",
+          "scoreOfEvidenceProvided": 1.6,
           "specifiedBy": "GeneValiditySegregationEvidenceCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/0087c979-8cb6-4959-bc64-07a48a61983b_family_segregation",
-              "type": "FamilyCosegregation",
+              "type": "FamilyCosegregation",              # This (and all similar objects below) would likely be representable by a new SEPIO/VA StudyResult subtype, which we could define to capture the info below
               "dc:description": "Sequenced more than 1 gene on the X, higher than just candidate gene sequencing",
               "dc:source": "https://pubmed.ncbi.nlm.nih.gov/22002931",
               "rdfs:label": "Strobl-Wildemann - Segregation Scoring",
@@ -542,26 +554,31 @@
     {
       "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_experimental_evidence_line",
       "type": "EvidenceLine",
-      "strengthScore": 5.5,
+	  "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+      "directionOfEvidenceProvided": "supports",
+      "scoreOfEvidenceProvided": 5.5,
       "specifiedBy": "GeneValidityOverallExperimentalEvidenceCriteria",
-      "evidence": [
+      "hasEvidenceItems": [
         {
           "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_model_rescue_evidence_line",
           "type": "EvidenceLine",
-          "strengthScore": 4,
+	      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk"
+          "directionOfEvidenceProvided": "Supports",  		  
+          "scoreOfEvidenceProvided": 4,
           "specifiedBy": "GeneValidityOverallModelAndRescueEvidenceCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/deed97dd-4578-43eb-a3ce-da52894a2871",
               "type": "EvidenceLine",
-              "direction": "Supports",
+	          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+              "directionOfEvidenceProvided": "Supports",
               "calculatedScore": 2,
-              "strengthScore": 2,
+              "scoreOfEvidenceProvided": 2,
               "specifiedBy": "GeneValidityNonHumanModelOrganismCriteria",
-              "evidence": [
+              "hasEvidenceItems": [
                 {
                   "id": "https://genegraph.clinicalgenome.org/r/5eba6a8b-c25d-45af-98c8-da8c414c4e97",
-                  "type": "Finding",
+                  "type": "Finding",        # This would likely be a new subtype of StudyResult we define for this particular type of study/finding
                   "dc:description": "In mice, as in humans, lack of Gdi1 spares most central nervous system ...",
                   "dc:source": "https://pubmed.ncbi.nlm.nih.gov/9620768",
                   "rdfs:label": "D'Adamo Models and Rescue - Animal Model",
@@ -574,11 +591,12 @@
             {
               "id": "https://genegraph.clinicalgenome.org/r/afafc2e1-d56b-4a5d-979b-9387bd99d844",
               "type": "EvidenceLine",
-              "direction": "Supports",
+	          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+              "directionOfEvidenceProvided": "Supports",
               "calculatedScore": 2,
-              "strengthScore": 2,
+              "scoreOfEvidenceProvided": 2,
               "specifiedBy": "GeneValidityNonHumanModelOrganismCriteria",
-              "evidence": [
+              "hasEvidenceItems": [
                 {
                   "id": "https://genegraph.clinicalgenome.org/r/5d2d55b4-230f-4216-9fa6-7ea136b6decd",
                   "type": "Finding",
@@ -596,20 +614,23 @@
         {
           "id": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca_functional_alteration_evidence_line",
           "type": "EvidenceLine",
-          "strengthScore": 1.5,
+	      "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+          "directionOfEvidenceProvided": "Supports",
+          "scoreOfEvidenceProvided": 1.5,
           "specifiedBy": "GeneValidityOverallFunctionalAlterationEvidenceCriteria",
-          "evidence": [
+          "hasEvidenceItems": [
             {
               "id": "https://genegraph.clinicalgenome.org/r/0cba6aac-e977-49e4-bdd8-e3647f0df7fb",
               "type": "EvidenceLine",
-              "direction": "Supports",
+	          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+              "directionOfEvidenceProvided": "Supports",
               "calculatedScore": 0.5,
-              "strengthScore": 0.5,
+              "scoreOfEvidenceProvided": 0.5,
               "specifiedBy": "GeneValidityNonPatientCellFunctionalAlterationCriteria",
-              "evidence": [
+              "hasEvidenceItems": [
                 {
                   "id": "https://genegraph.clinicalgenome.org/r/835c8dec-2d5b-4fd2-a96e-7911b8f5d2a0",
-                  "type": "FunctionalAlteration",
+                  "type": "FunctionalAlteration",                 # This would likely be a new subtype of StudyResult for this kind of Study/Finding
                   "dc:description": "Using electron microscopy and electrophysiology, we now report that ...",
                   "dc:source": "https://pubmed.ncbi.nlm.nih.gov/22291894",
                   "rdfs:label": "Bianchi - Functional Alteration Non-Patient Cells"
@@ -619,11 +640,12 @@
             {
               "id": "https://genegraph.clinicalgenome.org/r/eb6412d9-ddab-42d6-972f-9c9fc0dd6faa",
               "type": "EvidenceLine",
-              "direction": "Supports",
+	          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+              "directionOfEvidenceProvided": "Supports",
               "calculatedScore": 0.5,
-              "strengthScore": 0.5,
+              "scoreOfEvidenceProvided": 0.5,
               "specifiedBy": "GeneValidityNonPatientCellFunctionalAlterationCriteria",
-              "evidence": [
+              "hasEvidenceItems": [
                 {
                   "id": "https://genegraph.clinicalgenome.org/r/e965252c-86d9-492f-9f65-c2171638b368",
                   "type": "FunctionalAlteration",
@@ -636,11 +658,12 @@
             {
               "id": "https://genegraph.clinicalgenome.org/r/3e603d43-5f6f-4a8e-8c69-2324a5e78176",
               "type": "EvidenceLine",
-              "direction": "Supports",
+	          "targetProposition": "https://genegraph.clinicalgenome.org/r/20s_eD13bEk",
+              "directionOfEvidenceProvided": "Supports",
               "calculatedScore": 0.5,
-              "strengthScore": 0.5,
+              "scoreOfEvidenceProvided": 0.5,
               "specifiedBy": "GeneValidityNonPatientCellFunctionalAlterationCriteria",
-              "evidence": [
+              "hasEvidenceItems": [
                 {
                   "id": "https://genegraph.clinicalgenome.org/r/4691f380-6f9c-46d0-8ac4-97882cc974e9",
                   "type": "FunctionalAlteration",
@@ -655,7 +678,7 @@
       ]
     }
   ],
-  "sequence": 10957,
+  "sequence": 10957,                     # Not sure what the significance of this is?
   "GCISnapshot": "https://genegraph.clinicalgenome.org/r/8afc42b0-6c5e-460b-87d1-035c051fe7ca",
   "version": "1.0",
   "dc:isVersionOf": "https://genegraph.clinicalgenome.org/r/a0a9ec11-ef90-4095-9c9e-696eabd0395b",


### PR DESCRIPTION
Updated original ClinGen data example to be (mostly) SEPIO/VA-compliant. Also added some notes/questions as comments.

The purpose of this is to illustrate for Tristan what a fully SEPIO-compliant representation of the ClinGen gnee validity data would look like - using one record from their dataset. I created this as a PR so that Github would show the diffs to Tristan.  It is these diffs that are valuable - so no need to merge this.